### PR TITLE
chore(bitset): simple sparse bitset difference implementation

### DIFF
--- a/lib/sparse.js
+++ b/lib/sparse.js
@@ -1,0 +1,58 @@
+//
+// Sparse bitset is an array of ranges: [ { start, end }, { start, end }, ... ]
+//   * start and end are Numbers
+//   * ranges can overlap
+//   * no ordering
+//
+function diff (spans, events) {
+  events.forEach((event, next) => {
+    spans = spans.reduce((acc, span) => {
+      if (event.end <= span.start ||
+          event.start >= span.end) {
+        // No overlap
+        acc.push(span)
+      } else if (event.start >= span.start &&
+                 event.end <= span.end) {
+        // event: |---|
+        // span:  |----|
+        // span0: |
+        // span1:     ||
+        const span0 = {
+          start: span.start,
+          end: event.start
+        }
+        const span1 = {
+          start: event.end,
+          end: span.end
+        }
+
+        if (span0.start < span0.end) acc.push(span0)
+        if (span1.start < span1.end) acc.push(span1)
+      } else if (event.start <= span.start) {
+        // event: |---|
+        // span:    |---|
+        // span0:     |-|
+        const span0 = {
+          start: event.end,
+          end: span.end
+        }
+        if (span0.start < span0.end) acc.push(span0)
+      } else {
+        // event:   |---|
+        // span:  |---|
+        // span0: |-|
+        const span0 = {
+          start: span.start,
+          end: event.start
+        }
+        if (span0.start < span0.end) acc.push(span0)
+      }
+      return acc
+    }, [])
+  })
+  return spans
+}
+
+module.exports = {
+  diff
+}

--- a/test/sparse.js
+++ b/test/sparse.js
@@ -1,0 +1,95 @@
+/* eslint-env mocha */
+const { expect } = require('chai')
+
+const { diff } = require('../lib/sparse')
+
+describe('lib.sparse', () => {
+  describe('difference', () => {
+    it('handles no overlaps', () => {
+      const a = [
+        {
+          start: 0,
+          end: 2
+        }
+      ]
+      const b = [
+        {
+          start: 2,
+          end: 3
+        }
+      ]
+      const c = diff(a, b)
+      expect(c).to.deep.equal(a)
+    })
+
+    it('handles partial overlap with start', () => {
+      const a = [
+        {
+          start: 1,
+          end: 3
+        }
+      ]
+      const b = [
+        {
+          start: 0,
+          end: 2
+        }
+      ]
+      const c = diff(a, b)
+      expect(c).to.deep.equal([
+        {
+          start: 2,
+          end: 3
+        }
+      ])
+    })
+
+    it('handles partial overlap with end', () => {
+      const a = [
+        {
+          start: 0,
+          end: 2
+        }
+      ]
+      const b = [
+        {
+          start: 1,
+          end: 5
+        }
+      ]
+      const c = diff(a, b)
+      expect(c).to.deep.equal([
+        {
+          start: 0,
+          end: 1
+        }
+      ])
+    })
+
+    it('handles splitting', () => {
+      const a = [
+        {
+          start: 0,
+          end: 3
+        }
+      ]
+      const b = [
+        {
+          start: 1,
+          end: 2
+        }
+      ]
+      const c = diff(a, b)
+      expect(c).to.deep.equal([
+        {
+          start: 0,
+          end: 1
+        },
+        {
+          start: 2,
+          end: 3
+        }
+      ])
+    })
+  })
+})


### PR DESCRIPTION
I plan on using this to calculate "blocker" meetings. There are some other
bitset implementations, but all of them required some hacking to support
difference, so I made up my own sparse format.